### PR TITLE
Fix compatibility with ServerReplay

### DIFF
--- a/src/main/java/com/plusls/carpet/network/PcaSyncProtocol.java
+++ b/src/main/java/com/plusls/carpet/network/PcaSyncProtocol.java
@@ -89,7 +89,11 @@ public class PcaSyncProtocol {
             return;
         }
         PacketCodec<PacketByteBuf> codec = PacketCodec.of(
-                (p, buf) -> buf.writeBytes(p),
+                (p, buf) -> {
+                    int index = p.readerIndex();
+                    buf.writeBytes(p);
+                    p.readerIndex(index);
+                },
                 buf -> {
                     PacketByteBuf p = new PacketByteBuf(Unpooled.buffer());
                     p.writeBytes(buf);

--- a/src/main/java/com/plusls/carpet/network/PcaSyncProtocol.java
+++ b/src/main/java/com/plusls/carpet/network/PcaSyncProtocol.java
@@ -89,11 +89,7 @@ public class PcaSyncProtocol {
             return;
         }
         PacketCodec<PacketByteBuf> codec = PacketCodec.of(
-                (p, buf) -> {
-                    int index = p.readerIndex();
-                    buf.writeBytes(p);
-                    p.readerIndex(index);
-                },
+                (p, buf) -> buf.writeBytes(p.copy()),
                 buf -> {
                     PacketByteBuf p = new PacketByteBuf(Unpooled.buffer());
                     p.writeBytes(buf);


### PR DESCRIPTION
Fixes a compatibility issue with ServerReplay:  https://github.com/senseiwells/ServerReplay/issues/72.

As for why this should be fixed here: https://github.com/maruohon/servux/issues/12#issuecomment-2629672047

Summary:
ServerReplay writes packets to disk, thus packets may be written twice, pca's packet encoder is not pure, and encoding the packet once changes the internal state of the buffer meaning that the packet cannot be written again. This PR changes that to reset the reader index of the buffer so that the packet can be written multiple times.