### PR TITLE
Use `@Intrinsic` for lithium compatibility

### DIFF
--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinAbstractFurnaceBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinAbstractFurnaceBlockEntity.java
@@ -11,7 +11,11 @@ import net.minecraft.inventory.SidedInventory;
 import net.minecraft.recipe.RecipeInputProvider;
 import net.minecraft.recipe.RecipeUnlocker;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(AbstractFurnaceBlockEntity.class)
 public abstract class MixinAbstractFurnaceBlockEntity extends LockableContainerBlockEntity {
@@ -26,9 +30,15 @@ public abstract class MixinAbstractFurnaceBlockEntity extends LockableContainerB
         );
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
+
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update AbstractFurnaceBlockEntity: {}", this.pos);
         }

--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinBarrelBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinBarrelBlockEntity.java
@@ -8,7 +8,11 @@ import net.minecraft.block.entity.BarrelBlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.LootableContainerBlockEntity;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BarrelBlockEntity.class)
 public abstract class MixinBarrelBlockEntity extends LootableContainerBlockEntity {
@@ -22,10 +26,15 @@ public abstract class MixinBarrelBlockEntity extends LootableContainerBlockEntit
         );
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
 
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update BarrelBlockEntity: {}", this.pos);
         }

--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinBrewingStandBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinBrewingStandBlockEntity.java
@@ -9,7 +9,11 @@ import net.minecraft.block.entity.BrewingStandBlockEntity;
 import net.minecraft.block.entity.LockableContainerBlockEntity;
 import net.minecraft.inventory.SidedInventory;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BrewingStandBlockEntity.class)
 public abstract class MixinBrewingStandBlockEntity extends LockableContainerBlockEntity {
@@ -23,9 +27,15 @@ public abstract class MixinBrewingStandBlockEntity extends LockableContainerBloc
         );
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
+
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update BrewingStandBlockEntity: {}", this.pos);
         }

--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinChestBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinChestBlockEntity.java
@@ -8,7 +8,11 @@ import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.block.entity.LootableContainerBlockEntity;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 // 由于陷阱箱继承自箱子，因此不用 mixin 陷阱箱
 // implements ChestAnimationProgress 会出错 不知道为啥
@@ -24,9 +28,15 @@ public abstract class MixinChestBlockEntity extends LootableContainerBlockEntity
         );
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
+
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update ChestBlockEntity: {}", this.pos);
         }

--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinComparatorBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinComparatorBlockEntity.java
@@ -8,7 +8,11 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.ComparatorBlockEntity;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ComparatorBlockEntity.class)
 public abstract class MixinComparatorBlockEntity extends BlockEntity {
@@ -21,9 +25,15 @@ public abstract class MixinComparatorBlockEntity extends BlockEntity {
         );
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
+
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update ComparatorBlockEntity: {}", this.pos);
         }

--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinDispenserBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinDispenserBlockEntity.java
@@ -8,7 +8,11 @@ import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.DispenserBlockEntity;
 import net.minecraft.block.entity.LootableContainerBlockEntity;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(DispenserBlockEntity.class)
 public abstract class MixinDispenserBlockEntity extends LootableContainerBlockEntity {
@@ -22,9 +26,15 @@ public abstract class MixinDispenserBlockEntity extends LootableContainerBlockEn
         );
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
+
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update DispenserBlockEntity: {}", this.pos);
         }

--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinHopperBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinHopperBlockEntity.java
@@ -9,8 +9,11 @@ import net.minecraft.block.entity.Hopper;
 import net.minecraft.block.entity.HopperBlockEntity;
 import net.minecraft.block.entity.LootableContainerBlockEntity;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 //#if MC >= 11700
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -60,9 +63,15 @@ public abstract class MixinHopperBlockEntity extends LootableContainerBlockEntit
         //#endif
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
+
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update HopperBlockEntity: {}", this.pos);
         }

--- a/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinShulkerBoxBlockEntity.java
+++ b/src/main/java/com/plusls/carpet/mixin/rule/pcaSyncProtocol/block/MixinShulkerBoxBlockEntity.java
@@ -9,7 +9,11 @@ import net.minecraft.block.entity.LootableContainerBlockEntity;
 import net.minecraft.block.entity.ShulkerBoxBlockEntity;
 import net.minecraft.inventory.SidedInventory;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ShulkerBoxBlockEntity.class)
 public abstract class MixinShulkerBoxBlockEntity extends LootableContainerBlockEntity implements SidedInventory {
@@ -23,9 +27,15 @@ public abstract class MixinShulkerBoxBlockEntity extends LootableContainerBlockE
         );
     }
 
+    @Intrinsic
     @Override
     public void markDirty() {
         super.markDirty();
+    }
+
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(method = "markDirty", at = @At("RETURN"))
+    private void syncToClient(CallbackInfo ci) {
         if (PcaSettings.pcaSyncProtocol && PcaSyncProtocol.syncBlockEntityToClient(this)) {
             ModInfo.LOGGER.debug("update ShulkerBoxBlockEntity: {}", this.pos);
         }


### PR DESCRIPTION
lithium 在 0.14.1 版本之前，使用`@Intrinsic`来兼容其他mod对`markDirty()`的重写，但不知为何不生效🤔，会输出以下WARN:
```
Method overwrite conflict for method_5431 in pca.mixins.json:rule.pcaSyncProtocol.block.MixinAbstractFurnaceBlockEntity from mod pca-protocol, previously written by me.jellysquid.mods.lithium.mixin.world.block_entity_ticking.sleeping.furnace.AbstractFurnaceBlockEntityMixin. Skipping method.
Method overwrite conflict for method_5431 in pca.mixins.json:rule.pcaSyncProtocol.block.MixinBrewingStandBlockEntity from mod pca-protocol, previously written by me.jellysquid.mods.lithium.mixin.world.block_entity_ticking.sleeping.brewing_stand.BrewingStandBlockEntityMixin. Skipping method.
```
盲猜是mod id导致lithium先于pca加载而造成的。

兼容方法与lithium先前版本中的`@Intrinsic`写法差不多，虽然lithium[0.14.1+](https://github.com/CaffeineMC/lithium/commit/709b47b81e2164392db81604de8a08fe88bcf51b)有兼容性更强的写法，但不够优雅~~lazy😋~~